### PR TITLE
Fix PHP parse error and logic in legal page templates

### DIFF
--- a/page-cookie-policy.php
+++ b/page-cookie-policy.php
@@ -238,7 +238,8 @@ get_header();
                             Phone: <?php echo esc_html(get_theme_mod('footer_phone', '+254 738 788010')); ?></p>
                             <?php endif; ?>
                         </section>
-                        <?php endif; ?>
+                        <?php endif; // End of if (!$use_main_editor) ?>
+                    <?php } // Closing brace for the main 'else' block (fallback for if CPTs not found) ?>
                     </div>
                 </div>
 

--- a/page-privacy-policy.php
+++ b/page-privacy-policy.php
@@ -81,7 +81,7 @@ get_header();
                             ?>
                         </section>
                         <?php
-                        endif; // End of !$use_main_editor check
+                        // endif; // THIS PREMATURE ENDIF IS REMOVED to extend the if (!$use_main_editor) block
                         
                         // Add reusable legal clauses
                         $legal_clauses = new WP_Query(array(
@@ -112,7 +112,6 @@ get_header();
                             wp_reset_postdata();
                         }
                          ?>
-                         </section>
                          
                          <style>
                          .legal-section {
@@ -327,7 +326,8 @@ get_header();
                             Phone: <?php echo esc_html(get_theme_mod('footer_phone', '+254 738 788010')); ?></p>
                             <?php endif; ?>
                         </section>
-                        <?php endif; ?>
+                        <?php endif; // This is the endif for if (!$use_main_editor) which will be restructured ?>
+                    <?php } // Closing brace for the main 'else' block (fallback for if CPTs not found) ?>
                     </div>
                 </div>
 


### PR DESCRIPTION
- Resolved 'Unclosed {'' parse error in page-cookie-policy.php and page-privacy-policy.php by adding the missing closing curly brace for the main 'else' block.
- Corrected fallback content logic in page-privacy-policy.php by ensuring the 'if (!\$use_main_editor)' block wraps all static fallback sections.
- Removed an extraneous </section> tag in page-privacy-policy.php.

These changes address the critical errors reported in the logs and ensure proper fallback behavior.